### PR TITLE
[SDAO-385] Fix simple transaction signature

### DIFF
--- a/src/Data/Algorand/Transaction/Signed.hs
+++ b/src/Data/Algorand/Transaction/Signed.hs
@@ -54,10 +54,12 @@ data SignedTransaction = SignedTransaction
 --
 -- Note: this function will overwrite the sender of the transaction!
 signSimple :: SecretKey -> Transaction -> SignedTransaction
-signSimple sk txn = SignedTransaction
-  { stTxn = txn { tSender = fromPublicKey (toPublic sk) }
-  , stSig = SignatureSimple $ sign sk (serialiseTx txn)
-  }
+signSimple sk txn =
+  let txn' = txn { tSender = fromPublicKey (toPublic sk) }
+  in SignedTransaction
+    { stTxn = txn'
+    , stSig = SignatureSimple $ sign sk (serialiseTx txn')
+    }
 
 -- | Verify a simple signature transaction.
 verifySimple :: Signature -> Transaction -> Bool

--- a/test/algorand-lib/Test/Data/Algorand/Transaction/Signed.hs
+++ b/test/algorand-lib/Test/Data/Algorand/Transaction/Signed.hs
@@ -31,8 +31,8 @@ hprop_sign_verify_simple :: Property
 hprop_sign_verify_simple = property $ do
   Just sk <- skFromBytes <$> forAll genSecretKeyBytes
   tx <- forAll genTransaction
-  let tx' = tx { tSender = fromPublicKey (toPublic sk) }
-  tripping tx' (signSimple sk) verifyTransaction
+  let expectedTx = tx { tSender = fromPublicKey (toPublic sk) }
+  (verifyTransaction $ signSimple sk tx) === Just expectedTx
 
 hprop_signSimple_sets_sender :: Property
 hprop_signSimple_sets_sender = property $ do


### PR DESCRIPTION
Commit 0edbe1840cae1a19 introduced a bug where transactions
were signed before setting the sender field.

This restores it to how it was.

To verify, run the following commands:

halgo acc new ./example.acc
halgo acc new ./another.acc
halgo txn new pay $(halgo acc show ./another.acc) 100000 >/tmp/transaction
cat /tmp/transaction | halgo txn sign ./example.acc | halgo txn show