### PR TITLE
[SDAO-356] Add support for node status endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ $ halgo --network mainnet-v1.0 node --url https://example.com/ url
 https://example.com/
 ```
 
-Use `halgo node version` to get basic information about the node:
+Use `halgo node version` and `halgo node status` to get basic information about the node:
 
 ```text
 $ halgo node version
@@ -84,6 +84,25 @@ $ halgo node version
         "v2"
     ],
     "genesis_id": "testnet-v1.0"
+}
+
+$ halgo node status
+{
+    "time-since-last-round": 2848631166,
+    "catchpoint-verified-accounts": 0,
+    "last-round": 14004250,
+    "next-version": "https://github.com/algorandfoundation/specs/tree/d050b3cade6d5c664df8bd729bf219f179812595",
+    "catchup-time": 0,
+    "next-version-supported": true,
+    "last-catchpoint": "14000000#T2ETVH3DU4OMNFGYBNHOB26SAPGK477VVHG4XXXA62YTFNLS7BHQ",
+    "catchpoint-total-blocks": 0,
+    "catchpoint": "",
+    "catchpoint-total-accounts": 0,
+    "catchpoint-processed-accounts": 0,
+    "next-version-round": 14004251,
+    "catchpoint-acquired-blocks": 0,
+    "last-version": "https://github.com/algorandfoundation/specs/tree/d050b3cade6d5c664df8bd729bf219f179812595",
+    "stopped-at-unsupported-round": false
 }
 ```
 

--- a/app/halgo/Main.hs
+++ b/app/halgo/Main.hs
@@ -324,6 +324,9 @@ nodeOpts = cmdNode <$> optNodeUrl <*> sub
       , command "version" $ info
           (pure cmdNodeVersion)
           (progDesc "Query the version information of the node")
+      , command "status" $ info
+          (pure cmdNodeStatus)
+          (progDesc "Show the status of the node that will be used")
       , command "fetch" $ info
           (hsubparser $ mconcat
             [ command "acc" $ info
@@ -376,6 +379,9 @@ withNode url act = do
 cmdNodeVersion :: MonadSubcommand m => NodeUrl -> m ()
 cmdNodeVersion url = withNode url $ \(v, _) -> putJson v
 
+cmdNodeStatus :: MonadSubcommand m => NodeUrl -> m ()
+cmdNodeStatus url = withNode url $ \(_, api) ->
+  Api._status api >>= putJson
 
 -- | Fetch information about an account.
 cmdNodeFetchAccount :: MonadSubcommand m => A.Address -> NodeUrl -> m ()

--- a/src/Network/Algorand/Node/Api.hs
+++ b/src/Network/Algorand/Node/Api.hs
@@ -65,12 +65,32 @@ data Version = Version
   deriving (Generic, Show)
 $(deriveJSON algorandSnakeOptions 'Version)
 
-newtype NanoSec = NanoSec { unNanoSec :: Integer }
-  deriving stock (Eq, Ord, Show)
-  deriving newtype (ToJSON, FromJSON)
+newtype NanoSec = NanoSec { unNanoSec :: Word64 }
+  deriving stock (Eq, Show, Ord)
+  deriving newtype (Enum, Integral, Num, Real)
+  deriving newtype (FromJSON, ToJSON)
 
 data NodeStatus = NodeStatus
-  { nsCatchupTime :: NanoSec
+  { nsCatchpoint :: Maybe Text
+  -- ^ The current catchpoint that is being caught up to
+  , nsCatchpointAcquiredBlocks :: Maybe Word64
+  -- ^ The number of blocks that have already been
+  -- obtained by the node as part of the catchup
+  , nsCatchpointProcessedAccounts :: Maybe Word64
+  -- ^ The number of accounts from the current catchpoint
+  -- that have been processed so far as part of the catchup
+  , nsCatchpointTotalAccounts :: Maybe Word64
+  -- ^ The total number of accounts included in
+  -- the current catchpoint
+  , nsCatchpointTotalBlocks :: Maybe Word64
+  -- ^ The total number of blocks that are required to complete
+  -- the current catchpoint catchup
+  , nsCatchpointVerifiedAccounts :: Maybe Word64
+  -- ^ The number of accounts from the current catchpoint that
+  -- have been verified so far as part of the catchup
+  , nsCatchupTime :: NanoSec
+  , nsLastCatchpoint :: Maybe Text
+  -- ^ The last catchpoint seen by the node
   , nsLastRound :: Word64
   , nsLastVersion :: Text
   -- ^ indicates the last consensus version supported
@@ -85,25 +105,6 @@ data NodeStatus = NodeStatus
   -- ^ indicates that the node does not support
   -- the new rounds and has stopped making progress
   , nsTimeSinceLastRound :: NanoSec
-  , nsCatchpoint :: Maybe Text
-  -- ^ The current catchpoint that is being caught up to
-  , nsCatchpointAcquiredBlocks :: Maybe Integer
-  -- ^ The number of blocks that have already been
-  -- obtained by the node as part of the catchup
-  , nsCatchpointProcessedAccounts :: Maybe Integer
-  -- ^ The number of accounts from the current catchpoint
-  -- that have been processed so far as part of the catchup
-  , nsCatchpointTotalAccounts :: Maybe Integer
-  -- ^ The total number of accounts included in
-  -- the current catchpoint
-  , nsCatchpointTotalBlocks :: Maybe Integer
-  -- ^ The total number of blocks that are required to complete
-  -- the current catchpoint catchup
-  , nsCatchpointVerifiedAccounts :: Maybe Integer
-  -- ^ The number of accounts from the current catchpoint that
-  -- have been verified so far as part of the catchup
-  , nsLastCatchpoint :: Maybe Text
-  -- ^ The last catchpoint seen by the node
   }
 $(deriveJSON algorandTrainOptions 'NodeStatus)
 

--- a/src/Network/Algorand/Node/Api.hs
+++ b/src/Network/Algorand/Node/Api.hs
@@ -12,6 +12,8 @@ module Network.Algorand.Node.Api
 
   , BuildVersion (..)
   , Version (..)
+  , NanoSec (..)
+  , NodeStatus (..)
   , Account (..)
   , TransactionsRep (..)
   , TransactionInfo (..)
@@ -21,6 +23,7 @@ module Network.Algorand.Node.Api
 
 import GHC.Generics (Generic)
 
+import Data.Aeson (FromJSON, ToJSON)
 import Data.Aeson.TH (deriveJSON)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString.Lazy as BSL
@@ -61,6 +64,49 @@ data Version = Version
   }
   deriving (Generic, Show)
 $(deriveJSON algorandSnakeOptions 'Version)
+
+newtype NanoSec = NanoSec { unNanoSec :: Integer }
+  deriving stock (Eq, Ord, Show)
+  deriving newtype (ToJSON, FromJSON)
+
+data NodeStatus = NodeStatus
+  { nsCatchupTime :: NanoSec
+  , nsLastRound :: Word64
+  , nsLastVersion :: Text
+  -- ^ indicates the last consensus version supported
+  , nsNextVersion :: Text
+  -- ^ the next version of consensus protocol to use
+  , nsNextVersionRound :: Word64
+  -- ^ round at which the next consensus version will apply
+  , nsNextVersionSupported :: Bool
+  -- ^ indicates whether the next consensus version
+  -- is supported by this node
+  , nsStoppedAtUnsupportedRound :: Bool
+  -- ^ indicates that the node does not support
+  -- the new rounds and has stopped making progress
+  , nsTimeSinceLastRound :: NanoSec
+  , nsCatchpoint :: Maybe Text
+  -- ^ The current catchpoint that is being caught up to
+  , nsCatchpointAcquiredBlocks :: Maybe Integer
+  -- ^ The number of blocks that have already been
+  -- obtained by the node as part of the catchup
+  , nsCatchpointProcessedAccounts :: Maybe Integer
+  -- ^ The number of accounts from the current catchpoint
+  -- that have been processed so far as part of the catchup
+  , nsCatchpointTotalAccounts :: Maybe Integer
+  -- ^ The total number of accounts included in
+  -- the current catchpoint
+  , nsCatchpointTotalBlocks :: Maybe Integer
+  -- ^ The total number of blocks that are required to complete
+  -- the current catchpoint catchup
+  , nsCatchpointVerifiedAccounts :: Maybe Integer
+  -- ^ The number of accounts from the current catchpoint that
+  -- have been verified so far as part of the catchup
+  , nsLastCatchpoint :: Maybe Text
+  -- ^ The last catchpoint seen by the node
+  }
+$(deriveJSON algorandTrainOptions 'NodeStatus)
+
 
 data TransactionsRep = TransactionsRep
   { trTxId :: Text
@@ -140,7 +186,10 @@ data ApiAny route = ApiAny
 
 -- | Algod API (v2 only).
 data ApiV2 route = ApiV2
-  { _account :: route
+  { _status :: route
+      :- "status"
+      :> Get '[JSON] NodeStatus
+  , _account :: route
       :- "accounts"
       :> Capture "address" Address
       :> Get '[JSON] Account


### PR DESCRIPTION
Docs: https://developer.algorand.org/docs/reference/rest-apis/algod/v2/#get-v2status

This change is made entirely out of relevant parts from
  d4f783bd [SDAO-354] Add blocks and status API
  (part of #1)
with only minor changes:
 - typo fixes
 - no newtype for Round, raw Word64 is used
 - addition to readme