### PR TITLE
Add teal/compile endpoint support

### DIFF
--- a/algorand-sdk.cabal
+++ b/algorand-sdk.cabal
@@ -91,6 +91,7 @@ library
     , containers >=0.5 && <0.7
     , cryptonite >=0.1
     , data-default-class >=0.1.2 && <0.2
+    , fmt ==0.6.*
     , http-client-tls >=0.3.4 && <0.4
     , http-media >=0.1 && <0.9
     , memory >=0.1 && <0.16
@@ -231,6 +232,7 @@ test-suite algorand-lib-test
     , base32
     , base64
     , bytestring >=0.9 && <0.11
+    , fmt ==0.6.*
     , hedgehog
     , memory >=0.1 && <0.16
     , msgpack-binary

--- a/algorand-sdk.cabal
+++ b/algorand-sdk.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.2.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 
@@ -46,13 +46,46 @@ library
       Paths_algorand_sdk
   hs-source-dirs:
       src
-  default-extensions: AllowAmbiguousTypes BangPatterns ConstraintKinds DataKinds DefaultSignatures DeriveDataTypeable DeriveGeneric DerivingStrategies DuplicateRecordFields EmptyCase FlexibleContexts FlexibleInstances FunctionalDependencies GADTs GeneralizedNewtypeDeriving LambdaCase MultiParamTypeClasses MultiWayIf NamedFieldPuns OverloadedStrings OverloadedLabels PatternSynonyms RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TemplateHaskell TupleSections TypeFamilies TypeOperators UndecidableInstances ViewPatterns TypeApplications
+  default-extensions:
+      AllowAmbiguousTypes
+      BangPatterns
+      ConstraintKinds
+      DataKinds
+      DefaultSignatures
+      DeriveDataTypeable
+      DeriveGeneric
+      DerivingStrategies
+      DuplicateRecordFields
+      EmptyCase
+      FlexibleContexts
+      FlexibleInstances
+      FunctionalDependencies
+      GADTs
+      GeneralizedNewtypeDeriving
+      LambdaCase
+      MultiParamTypeClasses
+      MultiWayIf
+      NamedFieldPuns
+      OverloadedStrings
+      OverloadedLabels
+      PatternSynonyms
+      RankNTypes
+      RecordWildCards
+      ScopedTypeVariables
+      StandaloneDeriving
+      TemplateHaskell
+      TupleSections
+      TypeFamilies
+      TypeOperators
+      UndecidableInstances
+      ViewPatterns
+      TypeApplications
   ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints
   build-depends:
       aeson >=1.3 && <1.5
     , aeson-casing >=0.1.1.0 && <0.3
     , base >=4.7 && <4.15
-    , base32 >=0.2 && <0.3
+    , base32 ==0.2.*
     , base64 >=0.0.1.0 && <0.5
     , bytestring >=0.9 && <0.11
     , containers >=0.5 && <0.7
@@ -63,12 +96,13 @@ library
     , memory >=0.1 && <0.16
     , msgpack-binary >=0.0.14 && <0.1
     , msgpack-types >=0.0.4 && <0.1
-    , safe-exceptions >=0.1 && <0.2
+    , safe-exceptions ==0.1.*
     , scientific >=0.3.3 && <0.3.7
     , servant >=0.14 && <0.19
     , servant-client >=0.14 && <0.19
     , servant-client-core >=0.14 && <0.19
     , text >=0.1 && <1.3
+    , time
     , unordered-containers >=0.1.3 && <0.3
   default-language: Haskell2010
 
@@ -80,7 +114,40 @@ executable halgo
       Paths_algorand_sdk
   hs-source-dirs:
       app/halgo
-  default-extensions: AllowAmbiguousTypes BangPatterns ConstraintKinds DataKinds DefaultSignatures DeriveDataTypeable DeriveGeneric DerivingStrategies DuplicateRecordFields EmptyCase FlexibleContexts FlexibleInstances FunctionalDependencies GADTs GeneralizedNewtypeDeriving LambdaCase MultiParamTypeClasses MultiWayIf NamedFieldPuns OverloadedStrings OverloadedLabels PatternSynonyms RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TemplateHaskell TupleSections TypeFamilies TypeOperators UndecidableInstances ViewPatterns TypeApplications
+  default-extensions:
+      AllowAmbiguousTypes
+      BangPatterns
+      ConstraintKinds
+      DataKinds
+      DefaultSignatures
+      DeriveDataTypeable
+      DeriveGeneric
+      DerivingStrategies
+      DuplicateRecordFields
+      EmptyCase
+      FlexibleContexts
+      FlexibleInstances
+      FunctionalDependencies
+      GADTs
+      GeneralizedNewtypeDeriving
+      LambdaCase
+      MultiParamTypeClasses
+      MultiWayIf
+      NamedFieldPuns
+      OverloadedStrings
+      OverloadedLabels
+      PatternSynonyms
+      RankNTypes
+      RecordWildCards
+      ScopedTypeVariables
+      StandaloneDeriving
+      TemplateHaskell
+      TupleSections
+      TypeFamilies
+      TypeOperators
+      UndecidableInstances
+      ViewPatterns
+      TypeApplications
   ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints
   build-depends:
       aeson
@@ -91,17 +158,17 @@ executable halgo
     , bytestring >=0.9 && <0.11
     , directory >=1.2.7.0 && <1.4
     , filepath >=1.0 && <1.5
-    , fmt >=0.6 && <0.7
+    , fmt ==0.6.*
     , http-types >=0.1.1 && <0.13
     , memory >=0.1 && <0.16
     , mtl >=1.0 && <2.3
     , optparse-applicative >=0.15 && <0.17
-    , safe-exceptions >=0.1 && <0.2
+    , safe-exceptions ==0.1.*
     , servant-client
     , servant-client-core
     , text
     , unliftio >=0.1 && <0.3
-    , with-utf8 >=1.0 && <1.1
+    , with-utf8 ==1.0.*
   default-language: Haskell2010
 
 test-suite algorand-lib-test
@@ -119,7 +186,40 @@ test-suite algorand-lib-test
       Paths_algorand_sdk
   hs-source-dirs:
       test/algorand-lib
-  default-extensions: AllowAmbiguousTypes BangPatterns ConstraintKinds DataKinds DefaultSignatures DeriveDataTypeable DeriveGeneric DerivingStrategies DuplicateRecordFields EmptyCase FlexibleContexts FlexibleInstances FunctionalDependencies GADTs GeneralizedNewtypeDeriving LambdaCase MultiParamTypeClasses MultiWayIf NamedFieldPuns OverloadedStrings OverloadedLabels PatternSynonyms RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TemplateHaskell TupleSections TypeFamilies TypeOperators UndecidableInstances ViewPatterns TypeApplications
+  default-extensions:
+      AllowAmbiguousTypes
+      BangPatterns
+      ConstraintKinds
+      DataKinds
+      DefaultSignatures
+      DeriveDataTypeable
+      DeriveGeneric
+      DerivingStrategies
+      DuplicateRecordFields
+      EmptyCase
+      FlexibleContexts
+      FlexibleInstances
+      FunctionalDependencies
+      GADTs
+      GeneralizedNewtypeDeriving
+      LambdaCase
+      MultiParamTypeClasses
+      MultiWayIf
+      NamedFieldPuns
+      OverloadedStrings
+      OverloadedLabels
+      PatternSynonyms
+      RankNTypes
+      RecordWildCards
+      ScopedTypeVariables
+      StandaloneDeriving
+      TemplateHaskell
+      TupleSections
+      TypeFamilies
+      TypeOperators
+      UndecidableInstances
+      ViewPatterns
+      TypeApplications
   ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints
   build-tool-depends:
       tasty-discover:tasty-discover
@@ -134,7 +234,7 @@ test-suite algorand-lib-test
     , hedgehog
     , memory >=0.1 && <0.16
     , msgpack-binary
-    , safe-exceptions >=0.1 && <0.2
+    , safe-exceptions ==0.1.*
     , tasty
     , tasty-hedgehog
     , tasty-hunit

--- a/package.yaml
+++ b/package.yaml
@@ -26,6 +26,7 @@ dependencies:
   - memory >= 0.1 && < 0.16
   - safe-exceptions >= 0.1 && < 0.2
   - text >= 0.1 && < 1.3
+  - fmt >= 0.6 && < 0.7
 
 library:
   source-dirs: src
@@ -63,7 +64,6 @@ executables:
       - base64
       - directory >= 1.2.7.0 && < 1.4
       - filepath >= 1.0 && < 1.5
-      - fmt >= 0.6 && < 0.7
       - http-types >= 0.1.1 && < 0.13
       - mtl >= 1.0 && < 2.3
       - optparse-applicative >= 0.15 && < 0.17 # the lower bound is not tight

--- a/package.yaml
+++ b/package.yaml
@@ -20,7 +20,6 @@ extra-source-files:
   - CHANGELOG.md
   - README.md
 
-
 dependencies:
   - base >= 4.7 && < 4.15
   - bytestring >= 0.9 && < 0.11
@@ -48,6 +47,7 @@ library:
     - servant-client >= 0.14 && < 0.19
     - servant-client-core >= 0.14 && < 0.19
     - scientific >= 0.3.3 && < 0.3.7
+    - time
     - unordered-containers >= 0.1.3 && < 0.3
 
 executables:
@@ -66,7 +66,7 @@ executables:
       - fmt >= 0.6 && < 0.7
       - http-types >= 0.1.1 && < 0.13
       - mtl >= 1.0 && < 2.3
-      - optparse-applicative >= 0.15 && < 0.17  # the lower bound is not tight
+      - optparse-applicative >= 0.15 && < 0.17 # the lower bound is not tight
       - servant-client
       - servant-client-core
       - text
@@ -94,7 +94,6 @@ tests:
 
     build-tools:
       - tasty-discover:tasty-discover
-
 
 default-extensions:
   - AllowAmbiguousTypes


### PR DESCRIPTION
Problem:
Wo need to be able to compile teal scripts.

Solution:
Add support of the related entrypoint.
Also add Buildable and ByteArrayAccess instances for the Address type.

Note:
This is rework of PR #1.