### PR TITLE
Implement getBlock and [en/de]codeUintAppArgument helpers

### DIFF
--- a/algorand-sdk.cabal
+++ b/algorand-sdk.cabal
@@ -96,6 +96,7 @@ library
     , fmt ==0.6.*
     , http-client-tls >=0.3.4 && <0.4
     , http-media >=0.1 && <0.9
+    , http-types >=0.1.1 && <0.13
     , memory >=0.1 && <0.16
     , msgpack-binary >=0.0.14 && <0.1
     , msgpack-types >=0.0.4 && <0.1
@@ -236,6 +237,7 @@ test-suite algorand-lib-test
     , bytestring >=0.9 && <0.11
     , fmt ==0.6.*
     , hedgehog
+    , http-types >=0.1.1 && <0.13
     , memory >=0.1 && <0.16
     , msgpack-binary
     , safe-exceptions ==0.1.*

--- a/app/halgo/Main.hs
+++ b/app/halgo/Main.hs
@@ -399,14 +399,16 @@ cmdNodeStatus url = withNode url $ \(_, api) ->
 -- | Print block info.
 cmdPrintBlock :: MonadSubcommand m => B.Round -> NodeUrl -> m ()
 cmdPrintBlock rnd url = withNode url $ \(_, api) -> do
-  B.BlockWrapped block <- Api._block api rnd Api.msgPackFormat
-  let txs = TS.getUnverifiedTransaction <$> B.bTransactions block
-  putTextLn $
-    "Retrieved " +| (if null txs then "empty " else "" :: Text)
-    |+ "block for round " +| B.unRound (B.bRound block)
-    |+ " created at " +| B.bTimestamp block
-    |+ (if null txs then "" else " with txs:")
-  mapM_ putJson txs
+  mBlock <- N.getBlock api rnd
+  case mBlock of
+    Just block -> do
+      let txs = TS.getUnverifiedTransaction <$> B.bTransactions block
+      putTextLn $ "Retrieved " +| (if null txs then "empty " else "" :: Text)
+        |+ "block for round " +| B.unRound (B.bRound block)
+        |+ " created at " +| B.bTimestamp block
+        |+ (if null txs then "" else " with txs:")
+      mapM_ putJson txs
+    _ -> putTextLn "No block found"
 
 -- | Fetch information about an account.
 cmdNodeFetchAccount :: MonadSubcommand m => A.Address -> NodeUrl -> m ()

--- a/package.yaml
+++ b/package.yaml
@@ -23,10 +23,11 @@ extra-source-files:
 dependencies:
   - base >= 4.7 && < 4.15
   - bytestring >= 0.9 && < 0.11
+  - fmt >= 0.6 && < 0.7
+  - http-types >= 0.1.1 && < 0.13
   - memory >= 0.1 && < 0.16
   - safe-exceptions >= 0.1 && < 0.2
   - text >= 0.1 && < 1.3
-  - fmt >= 0.6 && < 0.7
 
 library:
   source-dirs: src
@@ -65,7 +66,6 @@ executables:
       - base64
       - directory >= 1.2.7.0 && < 1.4
       - filepath >= 1.0 && < 1.5
-      - http-types >= 0.1.1 && < 0.13
       - mtl >= 1.0 && < 2.3
       - optparse-applicative >= 0.15 && < 0.17 # the lower bound is not tight
       - servant-client

--- a/src/Data/Algorand/Block.hs
+++ b/src/Data/Algorand/Block.hs
@@ -36,7 +36,7 @@ type Addr = SizedByteArray 32 Bytes
 
 newtype Round = Round { unRound :: Word64 }
   deriving stock (Eq, Ord, Show)
-  deriving newtype (ToHttpApiData, ToJSON, FromJSON)
+  deriving newtype (Enum, ToHttpApiData, ToJSON, FromJSON)
 
 instance AlgoMessagePack Round where
   toAlgoObject = toAlgoObject . unRound

--- a/src/Data/Algorand/Transaction.hs
+++ b/src/Data/Algorand/Transaction.hs
@@ -26,16 +26,19 @@ module Data.Algorand.Transaction
   , transactionId'
 
   , serialiseTx
+  , encodeUintAppArgument
+  , decodeUintAppArgument
   ) where
 
 import qualified Data.Text as T
 
 import Data.Aeson (FromJSON (..), ToJSON (..))
+import Data.Binary (decodeOrFail, encode)
 import Data.ByteArray (Bytes)
 import Data.ByteArray.Sized (SizedByteArray, unSizedByteArray)
 import Data.ByteString (ByteString)
 import Data.ByteString.Base32 (encodeBase32Unpadded)
-import Data.ByteString.Lazy (toStrict)
+import Data.ByteString.Lazy (fromStrict, toStrict)
 import Data.MessagePack (pack)
 import Data.String (IsString)
 import Data.Text (Text)
@@ -349,3 +352,16 @@ instance ToJSON StateSchema where
 
 instance FromJSON StateSchema where
   parseJSON = parseCanonicalJson
+
+-- | Convert integer contract arguments (which passed as ByteString) to uint
+decodeUintAppArgument :: ByteString -> Maybe Word64
+decodeUintAppArgument = either (const Nothing) (pure . i3)
+  . decodeOrFail
+  . fromStrict
+  where
+    i3 (_, _, a) = a
+
+-- | Convert uint to ByteString
+-- (this is reversed version of 'decodeUintAppArgument')
+encodeUintAppArgument :: Word64 -> ByteString
+encodeUintAppArgument = toStrict . encode

--- a/src/Network/Algorand/Node/Util.hs
+++ b/src/Network/Algorand/Node/Util.hs
@@ -6,11 +6,22 @@
 module Network.Algorand.Node.Util
   ( TransactionStatus (..)
   , transactionStatus
+  , getBlock
   ) where
 
-import Data.Text (Text)
+import qualified Data.Aeson as J
+import qualified Data.HashMap.Strict as HM
 import qualified Data.Text as T
+
+import Control.Exception.Safe (MonadCatch, handle, throwM)
+import Data.Text (Text)
 import Data.Word (Word64)
+import Network.HTTP.Types (Status (statusCode))
+import Servant.Client (ClientError (..), ResponseF (..))
+import Servant.Client.Generic (AsClientT)
+
+import qualified Data.Algorand.Block as B
+import qualified Network.Algorand.Node.Api as Api
 
 import Network.Algorand.Node.Api (TransactionInfo (..))
 
@@ -29,3 +40,22 @@ transactionStatus TransactionInfo{tiConfirmedRound, tiPoolError} =
     Nothing -> case T.null tiPoolError of
       False -> KickedOut tiPoolError
       True -> Waiting
+
+-- | Catches error that has block absence for the round as the cause and
+-- return Nothing in this case. Other errors would be rethrown.
+getBlock
+  :: MonadCatch m
+  => Api.ApiV2 (AsClientT m) -> B.Round -> m (Maybe B.Block)
+getBlock api rnd = handle handler $ do
+  B.BlockWrapped block <- Api._block api rnd Api.msgPackFormat
+  pure (Just block)
+  where
+    noBlockMsg = "ledger does not have entry"
+    handler (FailureResponse _req
+              Response { responseStatusCode = s, responseBody = b })
+      | statusCode s == 500
+      , Just (J.Object errObj) <- J.decode' b
+      , Just (J.String msg) <- HM.lookup "message" errObj
+      , T.take (T.length noBlockMsg) msg == noBlockMsg
+      = pure Nothing
+    handler e = throwM e

--- a/src/Network/Algorand/Node/Util.hs
+++ b/src/Network/Algorand/Node/Util.hs
@@ -50,6 +50,7 @@ getBlock api rnd = handle handler $ do
   B.BlockWrapped block <- Api._block api rnd Api.msgPackFormat
   pure (Just block)
   where
+    -- note: this message depends on format, this one is for msgpack
     noBlockMsg = "ledger does not have entry"
     handler (FailureResponse _req
               Response { responseStatusCode = s, responseBody = b })


### PR DESCRIPTION
Problem:
1. Retrieving the block for round for which no block exists results into the error.
2. Integer contract arguments are passed as bytestrings. It's not obvious how to convert from bytestring to uint and vice versa.

Solution:
1. Introduce a `getBlock` function which catches error that has block absence for the round as the cause and return Nothing in this case. Other errors would be rethrown.
2. Allow to encode / decode from bytestring to Uint values.

Note:
This commit is rework of PR #1.

