### PR TITLE
Add fields to Account and properly decode signed txs from block

### DIFF
--- a/app/halgo/Main.hs
+++ b/app/halgo/Main.hs
@@ -402,7 +402,11 @@ cmdPrintBlock rnd url = withNode url $ \(_, api) -> do
   mBlock <- N.getBlock api rnd
   case mBlock of
     Just block -> do
-      let txs = TS.getUnverifiedTransaction <$> B.bTransactions block
+      let txs = TS.getUnverifiedTransaction . TS.toSignedTransaction
+                True -- false should be used only for some old protocol versions
+                (B.bGenesisHash block)
+                (B.bGenesisId block)
+            <$> B.bTransactions block
       putTextLn $ "Retrieved " +| (if null txs then "empty " else "" :: Text)
         |+ "block for round " +| B.unRound (B.bRound block)
         |+ " created at " +| B.bTimestamp block

--- a/src/Data/Algorand/Block.hs
+++ b/src/Data/Algorand/Block.hs
@@ -27,7 +27,7 @@ import Data.Algorand.Amount (Microalgos)
 import Data.Algorand.MessagePack (AlgoMessagePack (..), Canonical (..), MessageUnpackObject (..),
                                   (.:), (.:>), (.:?))
 import Data.Algorand.Transaction (GenesisHash)
-import Data.Algorand.Transaction.Signed (SignedTransaction)
+import Data.Algorand.Transaction.Signed (BlockTransaction)
 
 type BlockHash = SizedByteArray 32 Bytes
 type Seed = SizedByteArray 32 Bytes
@@ -129,7 +129,7 @@ data Block = Block
   -- ^ [seed] Sortition seed.
   , bTimestamp :: UTCTime
   -- ^ [ts] Block creation timestamp in seconds since epoch.
-  , bTransactions :: [SignedTransaction]
+  , bTransactions :: [BlockTransaction]
   -- ^ [txns] list of transactions corresponding
   -- to a given round.
   , bTransactionsRoot :: Maybe TransactionsRoot

--- a/src/Data/Algorand/MessagePack.hs
+++ b/src/Data/Algorand/MessagePack.hs
@@ -184,6 +184,10 @@ instance NonZeroValue [a] where
 instance NonZeroValue (SizedByteArray 32 b) where
   isNonZero _ = True
 
+instance NonZeroValue Bool where
+  isNonZero = id
+instance CanonicalZero Bool where
+  zero = False
 
 -- | An intermediate representation for non-primitive MessagePack objects
 -- that makes it easier to ensure that it is canonical.

--- a/src/Data/Algorand/Transaction/Signed.hs
+++ b/src/Data/Algorand/Transaction/Signed.hs
@@ -260,20 +260,24 @@ instance FromJSON LogicSignature where
 
 data BlockTransaction = BlockTransaction
   { btSig :: TransactionSignature
+  -- , btMsig :: MultiSignature
+  -- , btLsig :: LogicSig
   , btTxn :: Transaction
+  -- , btAuthAddr :: Address
   , btHgh :: Bool
   -- ^ [btHgh] whether the tx has genesis hash included in serialized representation.
   , btHgi :: Bool
   -- ^ [btHgi] whether the tx has genesis id included in serialized representation.
   -- , btApplyData :: ApplyData
+  -- https://github.com/algorand/go-algorand/blob/916154b5088e25472f68cc7f2971b63176a3889d/data/transactions/transaction.go#L102
   } deriving (Eq, Generic, Show)
 
 instance MessageUnpackObject BlockTransaction where
   fromCanonicalObject o = do
-    btTxn <- o .:> "txn"
     btSig <- fromCanonicalObject o
-    btHgi <- o .:? "hgi"
+    btTxn <- o .:> "txn"
     btHgh <- o .:? "hgh"
+    btHgi <- o .:? "hgi"
     pure BlockTransaction{..}
 
 instance MessagePackObject BlockTransaction where

--- a/src/Network/Algorand/Node/Api.hs
+++ b/src/Network/Algorand/Node/Api.hs
@@ -22,8 +22,8 @@ module Network.Algorand.Node.Api
   , TealCompilationResult (..)
   , Asset (..)
   , TealValue (..)
-  , TealKvEntry (..)
-  , TealKvStore
+  , TealKeyValue (..)
+  , TealKeyValueStore
   , LocalState (..)
   , tealValueBytesType
   , tealValueUintType
@@ -102,6 +102,7 @@ data NodeStatus = NodeStatus
   , nsLastCatchpoint :: Maybe Text
   -- ^ The last catchpoint seen by the node
   , nsLastRound :: Word64
+  -- ^ The last round seen
   , nsLastVersion :: Text
   -- ^ indicates the last consensus version supported
   , nsNextVersion :: Text
@@ -125,8 +126,11 @@ $(deriveJSON algorandCamelOptions 'TransactionsRep)
 
 data TealValue = TealValue
   { tvBytes :: ByteString
+  -- ^ bytes value.
   , tvUint :: Word64
+  -- ^ uint type.
   , tvType :: Word64
+  -- ^ value type.
   } deriving stock Show
 $(deriveJSON algorandTrainOptions 'TealValue)
 
@@ -136,13 +140,13 @@ tealValueBytesType = 1
 tealValueUintType :: Word64
 tealValueUintType = 2
 
-data TealKvEntry = TealKvEntry
+data TealKeyValue = TealKeyValue
   { tkeKey :: ByteString
   , tkeValue :: TealValue
   } deriving stock Show
-$(deriveJSON algorandTrainOptions 'TealKvEntry)
+$(deriveJSON algorandTrainOptions 'TealKeyValue)
 
-type TealKvStore = [TealKvEntry]
+type TealKeyValueStore = [TealKeyValue]
 
 data Asset = Asset
   { asAmount :: Word64
@@ -153,50 +157,60 @@ data Asset = Asset
   -- ^ Address that created this asset.
   -- This is the address where the parameters for this asset can be found, and
   -- also the address where unwanted asset units can be sent in the worst case.
-  , asDeleted :: Maybe Bool
-  -- ^ Whether or not the asset holding is currently deleted from its account.
   , asIsFrozen :: Bool
   -- ^ Whether or not the holding is frozen.
-  , asOptedInAtRound :: Maybe Round
-  -- ^ Round during which the account opted into this asset holding.
-  , asOptedOutAtRound :: Maybe Round
   }
   deriving stock Show
 $(deriveJSON algorandTrainOptions 'Asset)
 
 data LocalState = LocalState
-  { lsClosedOutAtRound :: Maybe Round
-  -- ^ Round when account closed out of the application.
-  , lsDeleted :: Maybe Bool
-  -- ^ Whether or not the application local state is currently deleted from
-  -- its account.
-  , lsId :: AppIndex
+  { lsId :: AppIndex
   -- ^ The application which this local state is for.
-  , lsKeyValue :: Maybe TealKvStore
+  , lsKeyValue :: Maybe TealKeyValueStore
   -- ^ Storage associated with the account and the application.
-  , lsOptedInAtRound :: Maybe Round
-  -- ^ Round when the account opted into the application.
   -- , schema :: ApplicationStateSchema
+  -- ^ Specifies maximums on the number of each type that may be stored.
   } deriving stock Show
 $(deriveJSON algorandTrainOptions 'LocalState)
 
 data Account = Account
   { aAddress :: Address
+  -- ^ the account public key.
   , aAmount :: Microalgos
+  -- ^ total number of MicroAlgos in the account.
   , aAmountWithoutPendingRewards :: Microalgos
+  -- ^ specifies the amount of MicroAlgos in the account, without the pending rewards.
   , aAppsLocalState :: Maybe [LocalState]
+  -- ^ applications local data stored in this account.
+  --, aAppsTotalExtraPages :: Maybe
+  -- ^ the sum of all extra application program pages for this account.
   --, aAppsTotalSchema :: Maybe StateSchema
+  -- ^ specifies maximums on the number of each type that may be stored.
   , aAssets :: Maybe [Asset]
+  -- ^ assets held by this account.
   , aAuthAddr :: Maybe Address
+  -- ^ the address against which signing should be checked.
+  -- If empty, the address of the current account is used. This field can be
+  -- updated in any transaction by setting the RekeyTo field.
   --, aCreatedApps :: Maybe
+  -- ^ parameters of applications created by this account including app global data.
   --, aCreatedAssets :: Maybe
+  -- ^ parameters of assets created by this account.
   --, aAccuntParticipation :: Maybe
+  -- ^ describes the parameters used by this account in consensus protocol.
   , aPendingRewards :: Microalgos
+  -- ^ amount of MicroAlgos of pending rewards in this account.
   , aRewardBase :: Maybe Microalgos
+  -- ^ used as part of the rewards computation. Only applicable to accounts
+  -- which are participating.
   , aRewards :: Microalgos
+  -- ^ total rewards of MicroAlgos the account has received, including pending rewards.
   , aRound :: Word64
+  -- ^ the round for which this information is relevant.
   --, aSigType :: Maybe
+  -- ^ indicates what type of signature is used by this account
   , aStatus :: Text
+  -- ^ delegation status of the account's MicroAlgos
   } deriving (Generic, Show)
 $(deriveJSON algorandTrainOptions 'Account)
 

--- a/src/Network/Algorand/Node/Util.hs
+++ b/src/Network/Algorand/Node/Util.hs
@@ -7,13 +7,20 @@ module Network.Algorand.Node.Util
   ( TransactionStatus (..)
   , transactionStatus
   , getBlock
+  , lookupAssetBalance
+  , lookupAppLocalState
   ) where
 
 import qualified Data.Aeson as J
 import qualified Data.HashMap.Strict as HM
+import qualified Data.Map as M
 import qualified Data.Text as T
 
 import Control.Exception.Safe (MonadCatch, handle, throwM)
+import Control.Monad (guard)
+import Data.ByteString (ByteString)
+import Data.Map (Map)
+import Data.Maybe (isNothing)
 import Data.Text (Text)
 import Data.Word (Word64)
 import Network.HTTP.Types (Status (statusCode))
@@ -23,6 +30,7 @@ import Servant.Client.Generic (AsClientT)
 import qualified Data.Algorand.Block as B
 import qualified Network.Algorand.Node.Api as Api
 
+import Data.Algorand.Transaction (AppIndex, AssetIndex)
 import Network.Algorand.Node.Api (TransactionInfo (..))
 
 
@@ -60,3 +68,33 @@ getBlock api rnd = handle handler $ do
       , T.take (T.length noBlockMsg) msg == noBlockMsg
       = pure Nothing
     handler e = throwM e
+
+-- | Helper to get asset balance at account
+lookupAssetBalance :: Api.Account -> AssetIndex -> Word64
+lookupAssetBalance Api.Account{..} assetId
+  | Just Api.Asset{..} <- aAssets >>= lookup assetId . map toPair
+  , isNothing asDeleted || Just False == asDeleted
+  , not asIsFrozen = asAmount
+  | otherwise = 0
+  where
+    toPair a@Api.Asset{..} = (asAssetId, a)
+
+-- | Helper to get account local state
+lookupAppLocalState
+  :: Api.Account
+  -> AppIndex
+  -> Maybe (Map ByteString (Either ByteString Word64))
+lookupAppLocalState Api.Account{..} appId = do
+  Api.LocalState{..} <- aAppsLocalState >>= lookup appId . map toPair
+  guard $ isNothing lsDeleted || Just False == lsDeleted
+  M.fromList . map toEntry <$> lsKeyValue
+  where
+    toPair a@Api.LocalState{..} = (lsId, a)
+    toEntry Api.TealKvEntry{..}
+      | Api.tvType tkeValue == Api.tealValueBytesType
+      = (tkeKey, Left $ Api.tvBytes tkeValue)
+      | Api.tvType tkeValue == Api.tealValueUintType
+      = (tkeKey, Right $ Api.tvUint tkeValue)
+      | otherwise = error $
+        "lookupAppLocalState: unknown teal value type "
+          <> show (Api.tvType tkeValue)


### PR DESCRIPTION
Problem:
1. Currently we do not fetch account assets and app state.
2. Transactions are serialized with no genesis id and hash fields in the block body.
    
Solution:
1. Add records to represent assets and app state, include this records to account one. Add helpers to get this data from account.
2. Extract "hgi" and "hgh" fields of transactions in block and allow to convert from a block transaction with these fields to a regular SignedTransaction.
    
Note:
This commit is rework of PR #1.