### PR TITLE
[SDAO-497] Add `health` and `versions` endpoint

### DIFF
--- a/src/Network/Algorand/Api/Indexer.hs
+++ b/src/Network/Algorand/Api/Indexer.hs
@@ -6,7 +6,8 @@
 --
 -- See <https://developer.algorand.org/docs/reference/rest-apis/indexer/>
 module Network.Algorand.Api.Indexer
-  ( IndexerApi (..)
+  ( Health (..)
+  , IndexerApi (..)
   , IdxAccountResponse (..)
   , TransactionResp (..)
   , transactionRespToTransaction
@@ -36,25 +37,7 @@ import Data.Algorand.Transaction (GenesisHash, Lease, Transaction (..), Transact
                                   TransactionType (..))
 import Network.Algorand.Api.Json (algorandTrainOptions)
 import Network.Algorand.Api.Node (Account)
-
-----------------
--- API
-----------------
-
--- | Indexer API.
-data IndexerApi route = IndexerApi
-  { _accountIdx :: route
-      :- "v2"
-      :> "accounts"
-      :> Capture "address" Address
-      :> QueryParam "round" Round
-      :> Get '[JSON] IdxAccountResponse
-  , _blockIdx :: route
-      :- "v2"
-      :> "blocks"
-      :> Capture "round" Round
-      :> Get '[JSON] BlockResp
-  } deriving stock (Generic)
+import Network.Algorand.Definitions (Network)
 
 ----------------
 -- Types
@@ -313,3 +296,38 @@ data BlockResp = BlockResp
 
 $(deriveJSON algorandTrainOptions 'IdxAccountResponse)
 $(deriveJSON algorandTrainOptions 'BlockResp)
+
+-- | Indexer health information.
+-- From: https://indexer.testnet.algoexplorerapi.io/health
+data Health = Health
+  { hDbAvailable :: Bool
+  , hGenesisHash :: Text
+  , hGenesisId :: Network
+  , hIsMigrating :: Bool
+  , hMessage :: Text
+  , hRound :: Round
+  , hVersion :: Text
+  } deriving (Generic, Show)
+$(deriveJSON algorandTrainOptions 'Health)
+
+----------------
+-- API
+----------------
+
+-- | Indexer API.
+data IndexerApi route = IndexerApi
+  { _health :: route
+      :- "health"
+      :> Get '[JSON] Health
+  , _accountIdx :: route
+      :- "v2"
+      :> "accounts"
+      :> Capture "address" Address
+      :> QueryParam "round" Round
+      :> Get '[JSON] IdxAccountResponse
+  , _blockIdx :: route
+      :- "v2"
+      :> "blocks"
+      :> Capture "round" Round
+      :> Get '[JSON] BlockResp
+  } deriving stock (Generic)

--- a/src/Network/Algorand/Api/Node.hs
+++ b/src/Network/Algorand/Api/Node.hs
@@ -193,7 +193,10 @@ $(deriveJSON algorandTrainOptions 'SuggestedParams)
 
 -- | Algod Node API
 data NodeApi route = NodeApi
-  { _status :: route
+  { _version :: route
+      :- "versions"
+      :> Get '[JSON] Version
+  , _status :: route
       :- "v2"
       :> "status"
       :> Get '[JSON] NodeStatus

--- a/test/algorand-lib/Test/Network/Algorand/Indexer/Golden.hs
+++ b/test/algorand-lib/Test/Network/Algorand/Indexer/Golden.hs
@@ -5,6 +5,7 @@
 module Test.Network.Algorand.Indexer.Golden
   ( unit_IdxAccountResponse
   , unit_BlockResp
+  , unit_Health
   ) where
 
 import Data.Aeson (FromJSON, eitherDecodeFileStrict')
@@ -12,7 +13,7 @@ import System.Directory (listDirectory)
 import System.FilePath ((</>))
 import Test.Tasty.HUnit (Assertion, assertFailure)
 
-import Network.Algorand.Api.Indexer (BlockResp, IdxAccountResponse)
+import Network.Algorand.Api.Indexer (BlockResp, Health, IdxAccountResponse)
 
 unit_IdxAccountResponse :: Assertion
 unit_IdxAccountResponse =
@@ -20,6 +21,9 @@ unit_IdxAccountResponse =
 
 unit_BlockResp :: Assertion
 unit_BlockResp = goldenTest @BlockResp (resourcesIndexer </> "blocks")
+
+unit_Health :: Assertion
+unit_Health = goldenTest @Health (resourcesIndexer </> "health")
 
 resourcesIndexer :: FilePath
 resourcesIndexer = "test/algorand-lib/resources/indexer"

--- a/test/algorand-lib/resources/indexer/health/health.json
+++ b/test/algorand-lib/resources/indexer/health/health.json
@@ -1,0 +1,9 @@
+{
+  "db-available": true,
+  "genesis-hash": "SGO1GKSzyE7IEPItTxCByw9x8FmnrCDexi9/cOUJOiI=",
+  "genesis-id": "testnet-v1.0",
+  "is-migrating": false,
+  "message": "16545654",
+  "round": 16545654,
+  "version": "1.1.2"
+}


### PR DESCRIPTION

## Description

Problem: The indexer's `/health` endpoint is no longer for internal used. We
should add support for it. Also node's `/versions` endpoint seems to be
missing as well.

Solution: Add indexer's `/health` and node's `/versions` endpoint and add tests for them.


## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves a part of https://issues.serokell.io/issue/SDAO-497

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)

#### Stylistic guide

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).

