### PR TITLE
[SDAO-497] Make `OnComplete` as sum types

### DIFF
--- a/src/Data/Algorand/MessagePack.hs
+++ b/src/Data/Algorand/MessagePack.hs
@@ -65,7 +65,7 @@ import Data.Function ((&))
 import Data.List (sortOn)
 import Data.MessagePack (Assoc (..), MessagePack (..), Object (..), pack)
 import Data.Text (Text)
-import Data.Word (Word64)
+import Data.Word (Word8, Word64)
 import GHC.TypeLits (KnownNat)
 
 unpack :: (Monad m, MonadFail m, MessagePack a) => LBS.ByteString -> m a
@@ -125,6 +125,10 @@ instance AlgoMessagePack Bool where
   fromAlgoObject = fromObject
 
 instance AlgoMessagePack ByteString where
+  toAlgoObject = toObject
+  fromAlgoObject = fromObject
+
+instance AlgoMessagePack Word8 where
   toAlgoObject = toObject
   fromAlgoObject = fromObject
 

--- a/test/algorand-lib/Test/Data/Algorand/Transaction.hs
+++ b/test/algorand-lib/Test/Data/Algorand/Transaction.hs
@@ -23,7 +23,7 @@ import Test.Tasty.HUnit (Assertion, (@?=))
 import Data.Algorand.Address (Address, fromPublicKey)
 import Data.Algorand.MessagePack (Canonical (Canonical, unCanonical), EitherError)
 import Data.Algorand.Round (Round (..))
-import Data.Algorand.Transaction (StateSchema (..), Transaction (..), TransactionType (..))
+import Data.Algorand.Transaction (OnComplete(..), StateSchema (..), Transaction (..), TransactionType (..))
 
 import Test.Crypto.Algorand.Signature (genPublicKey)
 import Test.Data.Algorand.Transaction.Examples (genesisHash, sender)
@@ -45,6 +45,9 @@ genSizedBytes gen = G.justT (sizedByteArray <$> gen (R.singleton size))
 genStateSchema :: MonadGen m => m StateSchema
 genStateSchema = StateSchema <$> G.word64 (R.linear 0 1000) <*> G.word64 (R.linear 0 1000)
 
+genOnComplete :: MonadGen m => m OnComplete
+genOnComplete = G.enumBounded
+
 genTransactionType :: MonadGen m => m TransactionType
 genTransactionType = G.choice
   [ PaymentTransaction
@@ -53,7 +56,7 @@ genTransactionType = G.choice
     <*> G.maybe genAddress
   , ApplicationCallTransaction
     <$> G.word64 R.constantBounded
-    <*> G.text (R.singleton 44) G.unicode
+    <*> genOnComplete
     <*> G.list (R.linear 0 10) genAddress
     <*> G.maybe (G.bytes $ R.linear 1 100)  -- cannot be empty
     <*> G.list (R.linear 0 10) (G.bytes (R.linear 0 32))

--- a/test/algorand-lib/Test/Data/Algorand/Transaction/Examples.hs
+++ b/test/algorand-lib/Test/Data/Algorand/Transaction/Examples.hs
@@ -18,7 +18,7 @@ import Test.Tasty.HUnit (Assertion, (@?=), assertFailure)
 import Data.Algorand.Address (Address)
 import Data.Algorand.MessagePack (Canonical (Canonical, unCanonical))
 import Data.Algorand.Transaction (GenesisHash, StateSchema (..), Transaction (..),
-                                  TransactionType (..), onCompleteNoOp, transactionId)
+                                  TransactionType (..), OnComplete (..), transactionId)
 import Data.Algorand.Transaction.Signed (getUnverifiedTransaction, verifyTransaction)
 
 
@@ -47,7 +47,7 @@ example_21 = Transaction
 
   , tTxType = ApplicationCallTransaction
     { actApplicationId = 100
-    , actOnComplete = onCompleteNoOp
+    , actOnComplete = OnCompleteNoOp
     , actAccounts = ["AAVDEAJ3NIYOG7XCRBKCJ3T5PUCVL2XASOP3NGX4NPPZ3UX6477PBG6E4Q", "AADQIC4PMKRTFMHAAXYAFSGAUULDI2ABBIYVQJ6GZ5JHY6DJPHTU2SPHYM"]
     , actApprovalProgram = Nothing
     , actAppArguments = ["test"]
@@ -70,16 +70,16 @@ unit_example_21_encoding =
     -- This was generated manually using Python SDK
     example_21_encoded :: ByteString
     example_21_encoded = result
-      "i6RhcGFhkcQEdGVzdKRhcGFupGNhbGykYXBhdJLEIAAqMgE7ajDjfuKIVCTufX0FVergk5+2mvxr353S/uf+xCAABwQLj2KjMrDgBfACyMClFjRoAQoxWCfGz1J8eGl556RhcGZhks0Vs80aCqRhcGlkZKNmZWXNBNKiZnbNIyiiZ2jEIDH9Ies45BCBGT7TTN87K4Poh0BUtH2cYYK+8N+SOOuDomx2zSMyo3NuZMQgCfvSdiwI+Gxa5r9t16epAd5mdddQ4H6MXHaYZH224f2kdHlwZaRhcHBs"
+      "iqRhcGFhkcQEdGVzdKRhcGF0ksQgACoyATtqMON+4ohUJO59fQVV6uCTn7aa/GvfndL+5/7EIAAHBAuPYqMysOAF8ALIwKUWNGgBCjFYJ8bPUnx4aXnnpGFwZmGSzRWzzRoKpGFwaWRko2ZlZc0E0qJmds0jKKJnaMQgMf0h6zjkEIEZPtNM3zsrg+iHQFS0fZxhgr7w35I464OibHbNIzKjc25kxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aR0eXBlpGFwcGw="
 
 -- Another extra test.
 unit_example_21_id :: Assertion
 unit_example_21_id =
-  transactionId example_21 @?= "C7HZ22XI4N33LDXG7UXIIMDJBINOBBE6A3D766EYGHLMRPIIDEZA"
+  transactionId example_21 @?= "2YIWKLZ2ZOJLINMGNKX3YIT67PUPVMIL72L3VBLDNJVEQAA6ZCWQ"
 
 example_21_expected :: ByteString
 example_21_expected = result
-  "gqNzaWfEQM1gWq1M1e6wevcO9v4qgBkV+AjP/Xu6raBCUcpXKPCS40EWfXjNppNrld08zSuz8GYm5sxPYGmx0Gkbe3E9nAGjdHhui6RhcGFhkcQEdGVzdKRhcGFupGNhbGykYXBhdJLEIAAqMgE7ajDjfuKIVCTufX0FVergk5+2mvxr353S/uf+xCAABwQLj2KjMrDgBfACyMClFjRoAQoxWCfGz1J8eGl556RhcGZhks0Vs80aCqRhcGlkZKNmZWXNBNKiZnbNIyiiZ2jEIDH9Ies45BCBGT7TTN87K4Poh0BUtH2cYYK+8N+SOOuDomx2zSMyo3NuZMQgCfvSdiwI+Gxa5r9t16epAd5mdddQ4H6MXHaYZH224f2kdHlwZaRhcHBs"
+  "gqNzaWfEQJIHH5XZSlICTW3xOEHpnQfguLb9dhNjnPZay9UGT8FZr+ig6XjnBher3QR4HDZmwg+3Ei5bPySgTb+5yVLRhwOjdHhuiqRhcGFhkcQEdGVzdKRhcGF0ksQgACoyATtqMON+4ohUJO59fQVV6uCTn7aa/GvfndL+5/7EIAAHBAuPYqMysOAF8ALIwKUWNGgBCjFYJ8bPUnx4aXnnpGFwZmGSzRWzzRoKpGFwaWRko2ZlZc0E0qJmds0jKKJnaMQgMf0h6zjkEIEZPtNM3zsrg+iHQFS0fZxhgr7w35I464OibHbNIzKjc25kxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aR0eXBlpGFwcGw="
 
 unit_example_21 :: Assertion
 unit_example_21 = try_example example_21 example_21_expected
@@ -95,7 +95,7 @@ example_22 = example_21
 
 example_22_expected :: ByteString
 example_22_expected = result
-  "gqNzaWfEQCeQtBiXAu8KJSGwQb5bVV3SxkjRQwxi38SmwXK6nDxcnOtMIwJlaOBYc61N6Bh9/H9rwK2n6xAWJpCbaxx1MAujdHhuiaRhcGFhkcQEdGVzdKRhcGFupGNhbGykYXBpZGSjZmVlzQTSomZ2zSMoomdoxCAx/SHrOOQQgRk+00zfOyuD6IdAVLR9nGGCvvDfkjjrg6Jsds0jMqNzbmTEIAn70nYsCPhsWua/bdenqQHeZnXXUOB+jFx2mGR9tuH9pHR5cGWkYXBwbA=="
+  "gqNzaWfEQIucoXp/ThFO4/An6dmp4oYVPojvyZZWYqn7nkKNfnm6qd/TXeu3qiPTEwrTEmhtU5qLGF3Ch+iDZeI6RmH24wujdHhuiKRhcGFhkcQEdGVzdKRhcGlkZKNmZWXNBNKiZnbNIyiiZ2jEIDH9Ies45BCBGT7TTN87K4Poh0BUtH2cYYK+8N+SOOuDomx2zSMyo3NuZMQgCfvSdiwI+Gxa5r9t16epAd5mdddQ4H6MXHaYZH224f2kdHlwZaRhcHBs"
 
 unit_example_22 :: Assertion
 unit_example_22 = try_example example_22 example_22_expected
@@ -110,7 +110,7 @@ example_23 = example_21
 
 example_23_expected :: ByteString
 example_23_expected = result
-  "gqNzaWfEQM/gZeGvub0ZnFe2ei++W3WZQIbhxNbBWweREWBZMPtPNE/kzRpWz2g3z3gniJweLTUo6LDK18VAd6QYSzc/3g+jdHhujKRhcGFhkcQEdGVzdKRhcGFupGNhbGykYXBhc5LNHmHNIrikYXBhdJLEIAAqMgE7ajDjfuKIVCTufX0FVergk5+2mvxr353S/uf+xCAABwQLj2KjMrDgBfACyMClFjRoAQoxWCfGz1J8eGl556RhcGZhks0Vs80aCqRhcGlkZKNmZWXNBNKiZnbNIyiiZ2jEIDH9Ies45BCBGT7TTN87K4Poh0BUtH2cYYK+8N+SOOuDomx2zSMyo3NuZMQgCfvSdiwI+Gxa5r9t16epAd5mdddQ4H6MXHaYZH224f2kdHlwZaRhcHBs"
+  "gqNzaWfEQEbhKgBScIWg4Cq9jLfSIE+LvH4hJSVGfU6ikR75waHFgIOy1Ut2dwdvkumHuiGzvJ0O0/ouMxnycqCyW49rWw6jdHhui6RhcGFhkcQEdGVzdKRhcGFzks0eYc0iuKRhcGF0ksQgACoyATtqMON+4ohUJO59fQVV6uCTn7aa/GvfndL+5/7EIAAHBAuPYqMysOAF8ALIwKUWNGgBCjFYJ8bPUnx4aXnnpGFwZmGSzRWzzRoKpGFwaWRko2ZlZc0E0qJmds0jKKJnaMQgMf0h6zjkEIEZPtNM3zsrg+iHQFS0fZxhgr7w35I464OibHbNIzKjc25kxCAJ+9J2LAj4bFrmv23Xp6kB3mZ111Dgfoxcdphkfbbh/aR0eXBlpGFwcGw="
 
 unit_example_23 :: Assertion
 unit_example_23 = try_example example_23 example_23_expected

--- a/test/algorand-lib/Test/Data/Algorand/Transaction/Signed.hs
+++ b/test/algorand-lib/Test/Data/Algorand/Transaction/Signed.hs
@@ -91,4 +91,4 @@ unit_sign_as_contract = do
     let signed = signFromContractAccount program [] example_21
     encodeBase64 (BSL.toStrict . MP.pack . MP.Canonical $ signed) @?= expected
   where
-    expected = "gqRsc2lngaFsxAUBIAEBIqN0eG6LpGFwYWGRxAR0ZXN0pGFwYW6kY2FsbKRhcGF0ksQgACoyATtqMON+4ohUJO59fQVV6uCTn7aa/GvfndL+5/7EIAAHBAuPYqMysOAF8ALIwKUWNGgBCjFYJ8bPUnx4aXnnpGFwZmGSzRWzzRoKpGFwaWRko2ZlZc0E0qJmds0jKKJnaMQgMf0h6zjkEIEZPtNM3zsrg+iHQFS0fZxhgr7w35I464OibHbNIzKjc25kxCD2di2sdbGZfWwslhgGgFB0kNeVES/+f7dgsnOK+cfxraR0eXBlpGFwcGw="
+    expected = "gqRsc2lngaFsxAUBIAEBIqN0eG6KpGFwYWGRxAR0ZXN0pGFwYXSSxCAAKjIBO2ow437iiFQk7n19BVXq4JOftpr8a9+d0v7n/sQgAAcEC49iozKw4AXwAsjApRY0aAEKMVgnxs9SfHhpeeekYXBmYZLNFbPNGgqkYXBpZGSjZmVlzQTSomZ2zSMoomdoxCAx/SHrOOQQgRk+00zfOyuD6IdAVLR9nGGCvvDfkjjrg6Jsds0jMqNzbmTEIPZ2Lax1sZl9bCyWGAaAUHSQ15URL/5/t2Cyc4r5x/GtpHR5cGWkYXBwbA=="


### PR DESCRIPTION
## Description

Problem: The fix to `OnComplete` parsers for indexer affects the encoding of it as
well which result in the encoding changes in the test. This is not
expected and the encoding shouldn't change.

Solution: Make `OnComplete` as sum types, its `AlgoMessagePack` instance
still expects it to be a number while its JSON instance expect it to be a string
instead, fix the tests.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves https://issues.serokell.io/issue/SDAO-497

## :white_check_mark: Checklist for your Pull Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](../tree/master/README.md)

#### Stylistic guide

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../tree/master/docs/code-style.md).

