### PR TITLE
[SDAO-499]: Add missing tx types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,15 @@ SPDX-License-Identifier: MPL-2.0
     * Microalgo amounts
     * Signing keys
     * Addresses
+    * Asset
     * Block
     * Round
 * Transaction types:
     * Payment transactions
     * Application call transactions
     * Asset transfer transactions
+    * Asset config transactions
+    * Asset freeze transactions
 * Canonical MessagePack serialisation
 * Signing and signature verification (only for simple single signatures)
 * Transaction groups

--- a/algorand-sdk.cabal
+++ b/algorand-sdk.cabal
@@ -37,6 +37,7 @@ library
       Crypto.Algorand.Util
       Data.Algorand.Address
       Data.Algorand.Amount
+      Data.Algorand.Asset
       Data.Algorand.Block
       Data.Algorand.MessagePack
       Data.Algorand.MessagePack.Json

--- a/halgo/Halgo/CLA/Argument.hs
+++ b/halgo/Halgo/CLA/Argument.hs
@@ -15,6 +15,7 @@ module Halgo.CLA.Argument
 
 import qualified Data.Text as T
 
+import Data.Text (Text)
 import Options.Applicative (Parser, action, argument, auto, eitherReader, help, metavar,
                             strArgument)
 
@@ -22,8 +23,7 @@ import qualified Data.Algorand.Address as A
 
 import Data.Algorand.Address (Address)
 import Data.Algorand.Amount (Microalgos)
-import Data.Algorand.Transaction (AssetIndex)
-import Data.Text (Text)
+import Data.Algorand.Asset (AssetIndex)
 
 argSecretFile :: Parser FilePath
 argSecretFile = strArgument $ mconcat

--- a/halgo/Halgo/CLA/Command/Transaction.hs
+++ b/halgo/Halgo/CLA/Command/Transaction.hs
@@ -13,15 +13,15 @@ import Control.Monad (forM_, when)
 import Options.Applicative (Parser, command, hsubparser, info, progDesc)
 import UnliftIO (liftIO)
 
-import qualified Data.Algorand.Address as A
-import qualified Data.Algorand.Amount as A
-import qualified Data.Algorand.Transaction as T
-import qualified Data.Algorand.Transaction.Build as T
-import qualified Data.Algorand.Transaction.Group as T
-import qualified Data.Algorand.Transaction.Signed as TS
 import qualified Network.Algorand.Api as Api
 
+import Data.Algorand.Address (Address, zero)
 import Data.Algorand.Amount (Microalgos)
+import Data.Algorand.Asset (AssetIndex)
+import Data.Algorand.Transaction (Transaction, TransactionType (..), transactionId)
+import Data.Algorand.Transaction.Build (buildTransaction)
+import Data.Algorand.Transaction.Group (isValidGroup, makeGroup)
+import Data.Algorand.Transaction.Signed (signFromContractAccount, signSimple, verifyTransaction)
 import Network.Algorand.Definitions (Host)
 
 import Halgo.CLA.Argument (argAddress, argAmount, argAssetIndex, argProgramFile, argSecretFile)
@@ -76,7 +76,7 @@ cmdTxnShow :: MonadSubCommand m => Bool -> Bool -> Bool -> m ()
 cmdTxnShow verify json base64 = do
   stxns <- if json then readItemsJson else readItemsB64
   when verify $
-    forM_ stxns $ \stxn -> case TS.verifyTransaction stxn of
+    forM_ stxns $ \stxn -> case verifyTransaction stxn of
       Nothing -> die "Invalid signature. Run with --no-verify if you still want to see it."
       Just _txn -> pure ()
   (if base64 then putItemsB64 else putItemsJson) stxns
@@ -84,7 +84,7 @@ cmdTxnShow verify json base64 = do
 -- | Show unsigned transactions.
 cmdTxnShowUnsigned :: MonadSubCommand m => Bool -> Bool -> m ()
 cmdTxnShowUnsigned json base64 =
-  (if json then readItemsJson else readItemsB64 @T.Transaction)
+  (if json then readItemsJson else readItemsB64 @Transaction)
   >>= if base64 then putItemsB64 else putItemsJson
 
 -- | Sign transactions with a simple signature.
@@ -92,7 +92,7 @@ cmdTxnSign :: MonadSubCommand m => Bool -> FilePath -> m ()
 cmdTxnSign json skFile = do
   sk <- loadAccount skFile
   txns <- if json then readItemsJson else readItemsB64
-  let signed = map (TS.signSimple sk) txns
+  let signed = map (signSimple sk) txns
   putItemsB64 signed
 
 -- | Sign transactions with a logic signature.
@@ -100,35 +100,37 @@ cmdTxnLogicSign :: MonadSubCommand m => Bool -> FilePath -> m ()
 cmdTxnLogicSign json programFile = do
   program <- liftIO $ BS.readFile programFile
   txns <- if json then readItemsJson else readItemsB64
-  let signed = map (TS.signFromContractAccount program []) txns
+  let signed = map (signFromContractAccount program []) txns
   putItemsB64 signed
 
 -- | Transaction ID.
 cmdTxnId :: MonadSubCommand m => Bool -> m ()
 cmdTxnId json = do
   txns <- if json then readItemsJson else readItemsB64
-  mapM_ (putTextLn . T.transactionId) txns
+  mapM_ (putTextLn . transactionId) txns
 
 -- | Create or check a group of transactions
 cmdTxnGroup :: MonadSubCommand m => Bool -> Bool -> m ()
 cmdTxnGroup json check = do
   txns <- if json then readItemsJson else readItemsB64
   case check of
-    True -> case T.isValidGroup txns of
+    True -> case isValidGroup txns of
       False -> die "Not a valid transaction group"
       True -> putItemsB64 txns
-    False -> putItemsB64 $ T.makeGroup txns
+    False -> putItemsB64 $ makeGroup txns
 
-cmdTxnNewPay :: MonadSubCommand m => A.Address -> A.Microalgos -> Host -> m ()
+cmdTxnNewPay :: MonadSubCommand m => Address -> Microalgos -> Host -> m ()
 cmdTxnNewPay to amnt url = withNode url $ \(_, api) -> do
   params <- Api._transactionsParams api
-  let payment = T.PaymentTransaction to amnt Nothing
-  let txn = T.buildTransaction params A.zero payment
+  let payment = PaymentTransaction to amnt Nothing
+  let txn = buildTransaction params zero payment
   putItemsB64 [txn]
 
-cmdTxnNewAxfr :: MonadSubCommand m => T.AssetIndex -> A.Address -> Microalgos -> Host -> m ()
+cmdTxnNewAxfr
+  :: MonadSubCommand m
+  => AssetIndex -> Address -> Microalgos -> Host -> m ()
 cmdTxnNewAxfr index to amnt url = withNode url $ \(_, api) -> do
   params <- Api._transactionsParams api
-  let payment = T.AssetTransferTransaction index amnt Nothing to Nothing
-  let txn = T.buildTransaction params A.zero payment
+  let payment = AssetTransferTransaction index amnt Nothing to Nothing
+  let txn = buildTransaction params zero payment
   putItemsB64 [txn]

--- a/src/Data/Algorand/Asset.hs
+++ b/src/Data/Algorand/Asset.hs
@@ -1,0 +1,76 @@
+-- SPDX-FileCopyrightText: 2021 Serokell <https://serokell.io>
+--
+-- SPDX-License-Identifier: MPL-2.0
+
+-- | Algorand asset.
+module Data.Algorand.Asset
+  ( AssetIndex
+  , Asset (..)
+  , AssetParams (..)
+  ) where
+
+import Data.Aeson.TH (deriveJSON)
+import Data.String (IsString)
+import Data.Word (Word64)
+
+import Data.Algorand.Address (Address)
+import Data.Algorand.Amount (Microalgos)
+import Data.Algorand.MessagePack (MessagePackObject (..), MessageUnpackObject (..), (&), (.:?),
+                                  (.=))
+import Network.Algorand.Api.Json (algorandTrainOptions)
+
+type AssetIndex = Word64
+
+data Asset = Asset
+  { asAmount :: Microalgos
+  -- ^ Number of units held.
+  , asAssetId :: AssetIndex
+  -- ^ Asset ID of the holding.
+  , asCreator :: Address
+  -- ^ Address that created this asset.
+  -- This is the address where the parameters for this asset can be found, and
+  -- also the address where unwanted asset units can be sent in the worst case.
+  , asIsFrozen :: Bool
+  -- ^ Whether or not the holding is frozen.
+  } deriving stock (Show, Eq)
+$(deriveJSON algorandTrainOptions 'Asset)
+
+data AssetParams = AssetParams
+  { acDecimals :: Word64
+  -- ^ [dc] The number of digits to use after the decimal point when displaying
+  -- this asset. If 0, the asset is not divisible. If 1, the base unit of the
+  -- asset is in tenths. If 2, the base unit of the asset is in hundredths,
+  -- and so on.
+  -- This value must be between 0 and 19 (inclusive).
+  , acTotal :: Word64
+  -- ^ [t] The total number of units of this asset.
+  } deriving stock (Show, Eq)
+$(deriveJSON algorandTrainOptions 'AssetParams)
+
+assetParamsFieldName :: IsString s => String -> s
+assetParamsFieldName = \case
+  "acDecimals" -> "dc"
+  "acTotal" -> "t"
+  x -> error $ "Unmapped asset params field name: " <> x
+
+instance MessagePackObject AssetParams where
+  toCanonicalObject = \case
+    AssetParams{..} -> mempty
+      & f "acDecimals" .= acDecimals
+      & f "acTotal" .= acTotal
+    where
+      f = assetParamsFieldName
+
+instance MessageUnpackObject AssetParams where
+  fromCanonicalObject o = do
+    acDecimals <- o .:? f "acDecimals"
+    acTotal <- o .:? f "acTotal"
+    pure AssetParams{..}
+    where
+      f = assetParamsFieldName
+
+-- apCreator :: Address
+--   -- ^ The address that created this asset.
+--   -- This is the address where the parameters for this asset can be found, and
+--   -- also the address where unwanted asset units can be sent in the worst case.
+--   ,

--- a/src/Network/Algorand/Api/Node.hs
+++ b/src/Network/Algorand/Api/Node.hs
@@ -14,7 +14,6 @@ module Network.Algorand.Api.Node
   , SuggestedParams (..)
   , NanoSec (..)
   , NodeStatus (..)
-  , Asset (..)
   , LocalState (..)
   , NodeApi (..)
   ) where
@@ -31,10 +30,11 @@ import Servant.API.Generic ((:-))
 
 import Data.Algorand.Address (Address)
 import Data.Algorand.Amount (Microalgos)
+import Data.Algorand.Asset (Asset, AssetIndex)
 import Data.Algorand.Block (BlockWrapped)
 import Data.Algorand.Round (Round)
 import Data.Algorand.Teal (TealCompilationResult, TealKeyValueStore)
-import Data.Algorand.Transaction (AppIndex, AssetIndex, GenesisHash)
+import Data.Algorand.Transaction (AppIndex, GenesisHash)
 import Data.Algorand.Transaction.Signed (SignedTransaction)
 import Network.Algorand.Api.Content (Binary, MsgPack)
 import Network.Algorand.Api.Json (algorandCamelOptions, algorandSnakeOptions, algorandTrainOptions)
@@ -111,21 +111,6 @@ newtype TransactionsRep = TransactionsRep
   { trTxId :: Text
   } deriving (Generic, Show)
 $(deriveJSON algorandCamelOptions 'TransactionsRep)
-
-data Asset = Asset
-  { asAmount :: Microalgos
-  -- ^ Number of units held.
-  , asAssetId :: AssetIndex
-  -- ^ Asset ID of the holding.
-  , asCreator :: Address
-  -- ^ Address that created this asset.
-  -- This is the address where the parameters for this asset can be found, and
-  -- also the address where unwanted asset units can be sent in the worst case.
-  , asIsFrozen :: Bool
-  -- ^ Whether or not the holding is frozen.
-  }
-  deriving stock Show
-$(deriveJSON algorandTrainOptions 'Asset)
 
 data LocalState = LocalState
   { lsId :: AppIndex

--- a/src/Network/Algorand/Util.hs
+++ b/src/Network/Algorand/Util.hs
@@ -31,9 +31,10 @@ import qualified Network.Algorand.Api as Api
 
 import Data.Algorand.Address (Address)
 import Data.Algorand.Amount (Microalgos)
+import Data.Algorand.Asset (Asset (..), AssetIndex)
 import Data.Algorand.Round (Round)
 import Data.Algorand.Teal (TealKeyValue (..), TealValue (..), tealValueBytesType, tealValueUintType)
-import Data.Algorand.Transaction (AppIndex, AssetIndex)
+import Data.Algorand.Transaction (AppIndex)
 import Network.Algorand.Api.Node (TransactionInfo (..))
 
 -- | Status of a transaction in the pool.
@@ -98,11 +99,11 @@ getAccountAtRound api addr rnd = handle noEntityHandler $
 -- | Helper to get asset balance at account
 lookupAssetBalance :: Api.Account -> AssetIndex -> Microalgos
 lookupAssetBalance Api.Account{..} assetId
-  | Just Api.Asset{..} <- aAssets >>= lookup assetId . map toPair
+  | Just Asset{..} <- aAssets >>= lookup assetId . map toPair
   , not asIsFrozen = asAmount
   | otherwise = 0
   where
-    toPair a@Api.Asset{..} = (asAssetId, a)
+    toPair a@Asset{..} = (asAssetId, a)
 
 -- | Helper to get account local state
 lookupAppLocalState


### PR DESCRIPTION
## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->
Problem:
Currently we receive invalid group logs pretty often, this is because
we do not have all instances for tx types, so we cannot check txs
correctly.

Solution:
Move `Asset` definition to its own module.
Add required fields for `AssetConfigTransaction` and `AssetFreezeTransaction`.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #1 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->
https://issues.serokell.io/issue/SDAO-499

## :white_check_mark: Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

#### Related changes (conditional)

- Tests
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [ ] I checked whether I should update the docs and did so if necessary:
    - [README](/README.md)
    - Haddock

- Public contracts
  - [x] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [x] I added an entry to the [changelog](/CHANGES.md) if my changes are visible to the users
        and
  - [ ] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](https://github.com/serokell/style).
