### PR TITLE
Deal with transaction groups

### DIFF
--- a/algorand-sdk.cabal
+++ b/algorand-sdk.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 24898c9594d4047704ec2b68a99c0a1fb8239a100761ac00b7c4b23305de39d2
+-- hash: c710368a656e5ddf49539157f7d054738262678dd65039877ffd13d316420f97
 
 name:           algorand-sdk
 version:        0.1.0.0
@@ -163,6 +163,7 @@ test-suite algorand-lib-test
     , containers
     , directory
     , filepath
+    , fmt
     , hedgehog
     , memory >=0.1 && <0.16
     , msgpack-binary

--- a/algorand-sdk.cabal
+++ b/algorand-sdk.cabal
@@ -1,8 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.33.0.
 --
 -- see: https://github.com/sol/hpack
+--
+-- hash: 24898c9594d4047704ec2b68a99c0a1fb8239a100761ac00b7c4b23305de39d2
 
 name:           algorand-sdk
 version:        0.1.0.0
@@ -58,60 +60,27 @@ library
       Paths_algorand_sdk
   hs-source-dirs:
       src
-  default-extensions:
-      AllowAmbiguousTypes
-      BangPatterns
-      ConstraintKinds
-      DataKinds
-      DefaultSignatures
-      DeriveDataTypeable
-      DeriveGeneric
-      DerivingStrategies
-      DuplicateRecordFields
-      EmptyCase
-      FlexibleContexts
-      FlexibleInstances
-      FunctionalDependencies
-      GADTs
-      GeneralizedNewtypeDeriving
-      LambdaCase
-      MultiParamTypeClasses
-      MultiWayIf
-      NamedFieldPuns
-      OverloadedLabels
-      OverloadedStrings
-      PatternSynonyms
-      RankNTypes
-      RecordWildCards
-      ScopedTypeVariables
-      StandaloneDeriving
-      TemplateHaskell
-      TupleSections
-      TypeApplications
-      TypeFamilies
-      TypeOperators
-      UndecidableInstances
-      ViewPatterns
+  default-extensions: AllowAmbiguousTypes BangPatterns ConstraintKinds DataKinds DefaultSignatures DeriveDataTypeable DeriveGeneric DerivingStrategies DuplicateRecordFields EmptyCase FlexibleContexts FlexibleInstances FunctionalDependencies GADTs GeneralizedNewtypeDeriving LambdaCase MultiParamTypeClasses MultiWayIf NamedFieldPuns OverloadedLabels OverloadedStrings PatternSynonyms RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TemplateHaskell TupleSections TypeApplications TypeFamilies TypeOperators UndecidableInstances ViewPatterns
   ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints
   build-depends:
       aeson >=1.3 && <1.6
     , aeson-casing >=0.1.1.0 && <0.3
     , base >=4.7 && <4.15
-    , base32 ==0.2.*
+    , base32 >=0.2 && <0.3
     , base64 >=0.0.1.0 && <0.5
     , binary
     , bytestring >=0.9 && <0.11
     , containers >=0.5 && <0.7
     , cryptonite >=0.1
     , data-default-class >=0.1.2 && <0.2
-    , fmt ==0.6.*
+    , fmt >=0.6 && <0.7
     , http-client-tls >=0.3.4 && <0.4
     , http-media >=0.1 && <0.9
     , http-types >=0.1.1 && <0.13
     , memory >=0.1 && <0.16
     , msgpack-binary >=0.0.14 && <0.1
     , msgpack-types >=0.0.4 && <0.1
-    , safe-exceptions ==0.1.*
+    , safe-exceptions >=0.1 && <0.2
     , scientific >=0.3.3 && <0.4
     , servant >=0.14 && <0.19
     , servant-client >=0.14 && <0.19
@@ -139,40 +108,7 @@ executable halgo
       Paths_algorand_sdk
   hs-source-dirs:
       halgo
-  default-extensions:
-      AllowAmbiguousTypes
-      BangPatterns
-      ConstraintKinds
-      DataKinds
-      DefaultSignatures
-      DeriveDataTypeable
-      DeriveGeneric
-      DerivingStrategies
-      DuplicateRecordFields
-      EmptyCase
-      FlexibleContexts
-      FlexibleInstances
-      FunctionalDependencies
-      GADTs
-      GeneralizedNewtypeDeriving
-      LambdaCase
-      MultiParamTypeClasses
-      MultiWayIf
-      NamedFieldPuns
-      OverloadedLabels
-      OverloadedStrings
-      PatternSynonyms
-      RankNTypes
-      RecordWildCards
-      ScopedTypeVariables
-      StandaloneDeriving
-      TemplateHaskell
-      TupleSections
-      TypeApplications
-      TypeFamilies
-      TypeOperators
-      UndecidableInstances
-      ViewPatterns
+  default-extensions: AllowAmbiguousTypes BangPatterns ConstraintKinds DataKinds DefaultSignatures DeriveDataTypeable DeriveGeneric DerivingStrategies DuplicateRecordFields EmptyCase FlexibleContexts FlexibleInstances FunctionalDependencies GADTs GeneralizedNewtypeDeriving LambdaCase MultiParamTypeClasses MultiWayIf NamedFieldPuns OverloadedLabels OverloadedStrings PatternSynonyms RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TemplateHaskell TupleSections TypeApplications TypeFamilies TypeOperators UndecidableInstances ViewPatterns
   ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints
   build-depends:
       aeson
@@ -181,16 +117,16 @@ executable halgo
     , base >=4.7 && <4.15
     , base64
     , bytestring >=0.9 && <0.11
-    , fmt ==0.6.*
+    , fmt >=0.6 && <0.7
     , http-types >=0.1.1 && <0.13
     , mtl >=1.0 && <2.3
     , optparse-applicative >=0.15 && <0.17
-    , safe-exceptions ==0.1.*
+    , safe-exceptions >=0.1 && <0.2
     , servant-client
     , servant-client-core
     , text
     , unliftio >=0.1 && <0.3
-    , with-utf8 ==1.0.*
+    , with-utf8 >=1.0 && <1.1
   default-language: Haskell2010
 
 test-suite algorand-lib-test
@@ -212,40 +148,7 @@ test-suite algorand-lib-test
       Paths_algorand_sdk
   hs-source-dirs:
       test
-  default-extensions:
-      AllowAmbiguousTypes
-      BangPatterns
-      ConstraintKinds
-      DataKinds
-      DefaultSignatures
-      DeriveDataTypeable
-      DeriveGeneric
-      DerivingStrategies
-      DuplicateRecordFields
-      EmptyCase
-      FlexibleContexts
-      FlexibleInstances
-      FunctionalDependencies
-      GADTs
-      GeneralizedNewtypeDeriving
-      LambdaCase
-      MultiParamTypeClasses
-      MultiWayIf
-      NamedFieldPuns
-      OverloadedLabels
-      OverloadedStrings
-      PatternSynonyms
-      RankNTypes
-      RecordWildCards
-      ScopedTypeVariables
-      StandaloneDeriving
-      TemplateHaskell
-      TupleSections
-      TypeApplications
-      TypeFamilies
-      TypeOperators
-      UndecidableInstances
-      ViewPatterns
+  default-extensions: AllowAmbiguousTypes BangPatterns ConstraintKinds DataKinds DefaultSignatures DeriveDataTypeable DeriveGeneric DerivingStrategies DuplicateRecordFields EmptyCase FlexibleContexts FlexibleInstances FunctionalDependencies GADTs GeneralizedNewtypeDeriving LambdaCase MultiParamTypeClasses MultiWayIf NamedFieldPuns OverloadedLabels OverloadedStrings PatternSynonyms RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TemplateHaskell TupleSections TypeApplications TypeFamilies TypeOperators UndecidableInstances ViewPatterns
   ghc-options: -Wall -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints
   build-tool-depends:
       tasty-discover:tasty-discover
@@ -257,6 +160,7 @@ test-suite algorand-lib-test
     , base32
     , base64
     , bytestring >=0.9 && <0.11
+    , containers
     , directory
     , filepath
     , hedgehog

--- a/halgo/Halgo/CLA/Argument.hs
+++ b/halgo/Halgo/CLA/Argument.hs
@@ -22,7 +22,7 @@ import qualified Data.Algorand.Address as A
 
 import Data.Algorand.Address (Address)
 import Data.Algorand.Amount (Microalgos)
-import Data.Algorand.Transaction (AssetIndex)
+import Data.Algorand.Transaction (AssetIndex (..))
 import Data.Text (Text)
 
 argSecretFile :: Parser FilePath
@@ -69,4 +69,4 @@ argAmount = argument auto $ mconcat
   ]
 
 argAssetIndex :: Parser AssetIndex
-argAssetIndex = argument auto (metavar "<asset>" <> help "Index of the asset")
+argAssetIndex = argument (AssetIndex <$> auto) (metavar "<asset>" <> help "Index of the asset")

--- a/package.yaml
+++ b/package.yaml
@@ -91,6 +91,7 @@ tests:
       - aeson
       - base32
       - base64
+      - containers
       - directory
       - filepath
       - msgpack-binary

--- a/package.yaml
+++ b/package.yaml
@@ -94,6 +94,7 @@ tests:
       - containers
       - directory
       - filepath
+      - fmt
       - msgpack-binary
       - memory >= 0.1 && < 0.16
       - servant-client-core

--- a/src/Data/Algorand/Transaction/Group.hs
+++ b/src/Data/Algorand/Transaction/Group.hs
@@ -19,7 +19,7 @@ import Data.Function ((&))
 
 import Crypto.Algorand.Hash (hash32)
 import Data.Algorand.MessagePack (pack, toAlgoObject, (.=))
-import Data.Algorand.Transaction (Transaction (..), TransactionGroupId, transactionId')
+import Data.Algorand.Transaction (Transaction (..), TransactionGroupId (..), transactionId')
 
 -- | Compute the group ID for a list of transactions.
 --
@@ -30,7 +30,7 @@ import Data.Algorand.Transaction (Transaction (..), TransactionGroupId, transact
 -- see 'areSupportedTransactions'.
 getGroupIdFor :: [Transaction] -> TransactionGroupId
 getGroupIdFor =
-    hash32 . ("TG" <>) . packGroup . map (transactionId' . setGroupId Nothing)
+    TransactionGroupId . hash32 . ("TG" <>) . packGroup . map (transactionId' . setGroupId Nothing)
   where
     packGroup :: [ByteString] -> ByteString
     packGroup txids = (BSL.toStrict . pack . toAlgoObject) $ mempty & "txlist" .= txids

--- a/src/Data/Algorand/Transaction/Group.hs
+++ b/src/Data/Algorand/Transaction/Group.hs
@@ -3,6 +3,9 @@
 -- SPDX-License-Identifier: MPL-2.0
 
 -- | Helpers for working with transaction groups.
+--
+-- NOTE: functions in this module are experimental and are not guaranteed
+-- to match the recent API.
 module Data.Algorand.Transaction.Group
   ( getGroupIdFor
   , makeGroup
@@ -22,6 +25,9 @@ import Data.Algorand.Transaction (Transaction (..), TransactionGroupId, transact
 --
 -- The order of transactions in the list matters!
 -- Make sure all transactions have all their fields filled in, including sender!
+--
+-- NB: this function works correctly only for supported transactions,
+-- see 'areSupportedTransactions'.
 getGroupIdFor :: [Transaction] -> TransactionGroupId
 getGroupIdFor =
     hash32 . ("TG" <>) . packGroup . map (transactionId' . setGroupId Nothing)
@@ -35,6 +41,9 @@ getGroupIdFor =
 -- and then overwrites the 'tGroup' field of each of the transactions with
 -- the computed value.
 -- Make sure all transactions have all their fields filled in, including sender!
+--
+-- NB: this function works correctly only for supported transactions,
+-- see 'areSupportedTransactions'.
 makeGroup :: [Transaction] -> [Transaction]
 makeGroup txs = map (setGroupId $ Just (getGroupIdFor txs)) txs
 
@@ -44,6 +53,9 @@ makeGroup txs = map (setGroupId $ Just (getGroupIdFor txs)) txs
 -- (have the same 'tGroup'), the group must be complete (i.e. the
 -- list must contain all transactions from the group), and the list
 -- must be in the right order.
+--
+-- NB: this function works correctly only for supported transactions,
+-- see 'areSupportedTransactions'.
 isValidGroup :: [Transaction] -> Bool
 isValidGroup txs =
   all (\Transaction{tGroup} -> tGroup == Just (getGroupIdFor txs)) txs

--- a/test/Test/Data/Algorand/Transaction.hs
+++ b/test/Test/Data/Algorand/Transaction.hs
@@ -9,18 +9,30 @@ module Test.Data.Algorand.Transaction
 
   , hprop_canonical_encode_decode
   , hprop_json_encode_decode
+
+  , test_transactions_group_validation
   ) where
 
 
+import Control.Monad (forM_)
 import Data.Aeson (fromJSON, toJSON)
-import Data.ByteString.Base64 (decodeBase64)
+import qualified Data.ByteArray as BA
+import Data.ByteString.Base64 (decodeBase64, encodeBase64)
 import Data.ByteString.Lazy (toStrict)
+import qualified Data.Map as Map
 import Data.MessagePack (pack, unpack)
+import qualified Data.Text.Encoding as T
 import Hedgehog (Property, forAll, property, tripping)
-import Test.Tasty.HUnit (Assertion, (@?=))
+import Test.Tasty (TestTree)
+import Test.Tasty.HUnit (Assertion, assertBool, testCaseSteps, (@?=))
+import Test.Util (idxClient)
 
 import Data.Algorand.MessagePack (Canonical (..), EitherError)
-import Data.Algorand.Transaction (Transaction (..), TransactionType (..))
+import Data.Algorand.Round
+import Data.Algorand.Transaction
+import Data.Algorand.Transaction.Group
+import Network.Algorand.Api.Indexer (TransactionResp (..))
+import qualified Network.Algorand.Api.Indexer as IdxApi
 
 import Test.Domain (genesisHash, sender)
 import Test.Gen (genTransaction)
@@ -61,3 +73,41 @@ hprop_json_encode_decode :: Property
 hprop_json_encode_decode = property $ do
   tx <- forAll genTransaction
   tripping tx toJSON fromJSON
+
+test_transactions_group_validation :: [TestTree]
+test_transactions_group_validation =
+  flip map
+    [ 0         -- just as an example
+    , 17608925  -- many txs in block
+
+    -- TODO: these do not work
+    -- , 17608932  -- has Config tx type
+    -- , 20853753, 20855687, 20856192  -- were not working at some moment
+    -- , 20856264  -- has Close tx type
+    ] $ \rid ->
+    testCaseSteps ("Round " <> show rid) $ \step -> do
+      cli <- idxClient
+      IdxApi.BlockResp
+        { brTransactions = txResps
+        , brGenesisId = gId
+        , brGenesisHash = gHash
+        } <- IdxApi._blockIdx cli (Round rid)
+
+      -- let txResps = fromMaybe (error "Unexpectedly no txs") mTxResps
+      let txs = IdxApi.transactionRespToTransaction gId gHash <$> txResps
+      let (_, groupedTxs) = splitTransactionsByGroup txs
+
+      -- Tx groups evaluation relies on 'transactionId', so we better check it too
+      forM_ (zip txResps txs) $ \(txResp, tx) ->
+        assertBool ("Transaction id is evaluated incorrectly for tx " <> show (trId txResp))
+          (trId txResp == transactionId tx)
+
+      forM_ (Map.toList groupedTxs) $ \(groupId, txsInGroup) -> do
+        -- TODO: have normal newtype for group id with Buildable instance
+        step $ "Checking group " <> show (T.encodeUtf8 (encodeBase64 $ BA.convert groupId))
+
+        assertBool "Group id is calculated incorrectly" $
+          (getGroupIdFor txsInGroup == groupId)
+
+        assertBool "Real group is considered invalid" $
+          isValidGroup txsInGroup

--- a/test/Test/Data/Algorand/Transaction.hs
+++ b/test/Test/Data/Algorand/Transaction.hs
@@ -16,12 +16,11 @@ module Test.Data.Algorand.Transaction
 
 import Control.Monad (forM_)
 import Data.Aeson (fromJSON, toJSON)
-import qualified Data.ByteArray as BA
-import Data.ByteString.Base64 (decodeBase64, encodeBase64)
+import Data.ByteString.Base64 (decodeBase64)
 import Data.ByteString.Lazy (toStrict)
 import qualified Data.Map as Map
 import Data.MessagePack (pack, unpack)
-import qualified Data.Text.Encoding as T
+import Fmt ((+|), (|+))
 import Hedgehog (Property, forAll, property, tripping)
 import Test.Tasty (TestTree)
 import Test.Tasty.HUnit (Assertion, assertBool, testCaseSteps, (@?=))
@@ -103,8 +102,7 @@ test_transactions_group_validation =
           (trId txResp == transactionId tx)
 
       forM_ (Map.toList groupedTxs) $ \(groupId, txsInGroup) -> do
-        -- TODO: have normal newtype for group id with Buildable instance
-        step $ "Checking group " <> show (T.encodeUtf8 (encodeBase64 $ BA.convert groupId))
+        step $ "Checking group " +| groupId |+ ""
 
         assertBool "Group id is calculated incorrectly" $
           (getGroupIdFor txsInGroup == groupId)

--- a/test/Test/Data/Algorand/Transaction/AssetTransfer.hs
+++ b/test/Test/Data/Algorand/Transaction/AssetTransfer.hs
@@ -13,7 +13,7 @@ import Data.MessagePack (pack)
 import Test.Tasty.HUnit (Assertion, (@?=))
 
 import Data.Algorand.MessagePack (Canonical (Canonical))
-import Data.Algorand.Transaction (Transaction (..), TransactionType (..))
+import Data.Algorand.Transaction (AssetIndex (..), Transaction (..), TransactionType (..))
 
 import Test.Domain (genesisHash)
 import Test.Util (decodeExpected)
@@ -30,7 +30,7 @@ example = Transaction
   , tGenesisHash = genesisHash
 
   , tTxType = AssetTransferTransaction
-    { attXferAsset = 1234
+    { attXferAsset = AssetIndex 1234
     , attAssetAmount = 1234567
     , attAssetSender = Nothing
     , attAssetReceiver = "OKL27YOBRCNNVQDQQ6UFC6IX7Z4BJ7EPBS3TSSAZ6V54SKYTTCMKUFCOIA"

--- a/test/Test/Data/Algorand/Transaction/Examples.hs
+++ b/test/Test/Data/Algorand/Transaction/Examples.hs
@@ -21,8 +21,8 @@ import Data.MessagePack (pack, unpack)
 import Test.Tasty.HUnit (Assertion, assertFailure, (@?=))
 
 import Data.Algorand.MessagePack (Canonical (Canonical, unCanonical))
-import Data.Algorand.Transaction (OnComplete (..), StateSchema (..), Transaction (..),
-                                  TransactionType (..), transactionId)
+import Data.Algorand.Transaction (AppIndex (..), AssetIndex (..), OnComplete (..), StateSchema (..),
+                                  Transaction (..), TransactionType (..), transactionId)
 import Data.Algorand.Transaction.Signed (getUnverifiedTransaction, verifyTransaction)
 
 import Test.Domain (genesisHash, sender)
@@ -49,13 +49,13 @@ example_21 = Transaction
   , tGenesisHash = genesisHash
 
   , tTxType = ApplicationCallTransaction
-    { actApplicationId = 100
+    { actApplicationId = AppIndex 100
     , actOnComplete = OnCompleteNoOp
     , actAccounts = ["AAVDEAJ3NIYOG7XCRBKCJ3T5PUCVL2XASOP3NGX4NPPZ3UX6477PBG6E4Q", "AADQIC4PMKRTFMHAAXYAFSGAUULDI2ABBIYVQJ6GZ5JHY6DJPHTU2SPHYM"]
     , actApprovalProgram = Nothing
     , actAppArguments = ["test"]
     , actClearStateProgram = Nothing
-    , actForeignApps = [5555, 6666]
+    , actForeignApps = map AppIndex [5555, 6666]
     , actForeignAssets = []
     , actGlobalStateSchema = Just $ StateSchema 0 0
     , actLocalStateSchema = Just $ StateSchema 0 0
@@ -102,7 +102,7 @@ unit_example_22 = try_example example_22 expected
 example_23 :: Transaction
 example_23 = example_21
   { tTxType = (tTxType example_21)
-    { actForeignAssets = [7777, 8888]
+    { actForeignAssets = map AssetIndex [7777, 8888]
     }
   }
 

--- a/test/Test/Gen.hs
+++ b/test/Test/Gen.hs
@@ -24,8 +24,7 @@ import Crypto.Algorand.Key (PublicKey, pkFromBytes, pkSize, skFromBytes, skSize)
 import Data.Algorand.Address (Address, fromPublicKey)
 import Data.Algorand.Amount (microAlgos)
 import Data.Algorand.Round (Round (..))
-import Data.Algorand.Transaction (OnComplete (..), StateSchema (..), Transaction (..),
-                                  TransactionType (..))
+import Data.Algorand.Transaction
 
 import Test.Domain (Signer (..))
 
@@ -85,18 +84,18 @@ genTransactionType = G.choice
     <*> G.integral R.linearBounded
     <*> G.maybe genAddress
   , ApplicationCallTransaction
-    <$> G.word64 R.constantBounded
+    <$> (AppIndex <$> G.word64 R.constantBounded)
     <*> genOnComplete
     <*> G.list (R.linear 0 10) genAddress
     <*> G.maybe (G.bytes $ R.linear 1 100)  -- cannot be empty
     <*> G.list (R.linear 0 10) (G.bytes (R.linear 0 32))
     <*> G.maybe (G.bytes $ R.linear 1 100)  -- cannot be empty
-    <*> G.list (R.linear 0 10) (G.word64 (R.linear 0 10000))
-    <*> G.list (R.linear 0 10) (G.word64 (R.linear 0 10000))
+    <*> G.list (R.linear 0 10) (AppIndex <$> G.word64 (R.linear 0 10000))
+    <*> G.list (R.linear 0 10) (AssetIndex <$> G.word64 (R.linear 0 10000))
     <*> (Just <$> genStateSchema)
     <*> (Just <$> genStateSchema)
   , AssetTransferTransaction
-    <$> G.word64 R.constantBounded
+    <$> (AssetIndex <$> G.word64 R.constantBounded)
     <*> genAmount
     <*> G.maybe genAddress
     <*> genAddress
@@ -115,10 +114,10 @@ genTransaction =
   <*> genRound
   <*> G.maybe (G.bytes $ R.linear 1 100)  -- cannot be empty
   <*> G.maybe (G.text (R.singleton 44) G.unicode)
-  <*> G.maybe (genSizedBytes genBytes)
+  <*> G.maybe (GenesisHash <$> genSizedBytes genBytes)
   <*> genTransactionType
-  <*> G.maybe (genSizedBytes genBytes)
-  <*> G.maybe (genSizedBytes genBytes)
+  <*> G.maybe (TransactionGroupId <$> genSizedBytes genBytes)
+  <*> G.maybe (Lease <$> genSizedBytes genBytes)
   <*> G.maybe genAddress
   where
     genRound = Round <$> G.word64 R.constantBounded

--- a/test/Test/Util.hs
+++ b/test/Test/Util.hs
@@ -27,7 +27,7 @@ import Test.Tasty.HUnit (Assertion, assertFailure, (@?=))
 
 import qualified Network.Algorand.Api as Api
 
-import Data.Algorand.Transaction (GenesisHash)
+import Data.Algorand.Transaction (GenesisHash (..))
 import Network.Algorand.Client (AlgoIndexer (..), AlgoNode (..), connectToIndexer, connectToNode)
 import Network.Algorand.Definitions (DefaultHost (..), Network (TestnetV1), getDefaultHost)
 
@@ -62,7 +62,7 @@ split c xs = second (drop 1) . break (== c) $ xs
 -- | Get 'GenesisHash' from 'ByteString'
 genesisHashFromBytes :: ByteString -> Maybe GenesisHash
 genesisHashFromBytes t = case decodeBase64 t of
-  Right bs -> sizedByteArray $ convert bs
+  Right bs -> GenesisHash <$> sizedByteArray (convert bs)
   Left _ -> Nothing
 
 -- | Decode base64 'ByteString'


### PR DESCRIPTION
## Description

We suffer from `isValidGroup` constantly returning `False` for valid transaction groups, this PR helps in fixing this situation (full proper fix is unavailable at this development stage).

Please see commit's descriptions. 

`isValidGroup` was just an extra check on that the data returned by the Indexer is sane. And, like, it does not seem necessary, we can completely skip it. Maybe only have a test on it in _this repository_ to check that _our processing_ of data coming from Indexer API is correct. And asserting the Indexer's output this way - this just increases an area for bugs, I don't thing it carries any benefit at this stage of life of our SDK.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #1 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

## :white_check_mark: Checklist for your Pull Request

Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

#### Related changes (conditional)

- Tests
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - [x] I checked whether I should update the docs and did so if necessary:
    - [README](/README.md)
    - Haddock

- Public contracts
  - [ ] Any modifications of public contracts comply with the [Evolution
  of Public Contracts](https://www.notion.so/serokell/Evolution-of-Public-Contracts-2a3bf7971abe4806a24f63c84e7076c5) policy.
  - [ ] I added an entry to the [changelog](/CHANGES.md) if my changes are visible to the users
        and
  - [ ] provided a migration guide for breaking changes if possible

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](https://github.com/serokell/style).
